### PR TITLE
Don't add duplicate WebtestUserMiddleware to the list of middlewares in WebTestMixin

### DIFF
--- a/django_webtest/__init__.py
+++ b/django_webtest/__init__.py
@@ -272,7 +272,7 @@ class WebTestMixin(object):
             # middleware to the end.  If appending causes problems
             # _setup_auth_middleware method can be overriden by a subclass.
             self.settings_middleware.append(webtest_auth_middleware)
-        else:
+        elif webtest_auth_middleware not in self.settings_middleware:
             index = self.settings_middleware.index(django_auth_middleware)
             self.settings_middleware.insert(index + 1, webtest_auth_middleware)
 


### PR DESCRIPTION
I ran into problems when adding a large number of tests to our repo that all used django_app_factory. Every test adds a new instance of WebtestUserMiddleware to the WebTestMixin.settings_middleware, which eventually leads to hitting the max stack size and causing tests to fail.

In WebTestMixin._setup_auth_middleware, added a check for whether WebTestMixin is already in the list in before adding it.